### PR TITLE
Fix multiples errors with beatifulsoup4 and async packages

### DIFF
--- a/domi_owned/enumerate.py
+++ b/domi_owned/enumerate.py
@@ -97,14 +97,16 @@ class Enumerate(DomiOwned):
 		else:
 			client = aiohttp.ClientSession(headers=self.utilities.HEADERS, loop=loop)
 
-		with client as session:
-			try:
-				loop.run_until_complete(self.query(session, urls))
-			except asyncio.CancelledError:
-				sys.exit()
-			except Exception as error:
-				self.logger.error('An error occurred while enumerating Domino URLs')
-				sys.exit()
+		#with client as session:
+		try:
+			task = loop.create_task(self.query(client, urls))
+			loop.run_until_complete(task)
+			loop.close()
+		except asyncio.CancelledError:
+			sys.exit()
+		except Exception as error:
+			self.logger.error('An error occurred while enumerating Domino URLs')
+			sys.exit()
 
 	async def query(self, session, urls):
 		"""

--- a/domi_owned/hashdump.py
+++ b/domi_owned/hashdump.py
@@ -112,14 +112,16 @@ class HashDump(DomiOwned):
 		else:
 			client = aiohttp.ClientSession(headers=self.utilities.HEADERS, loop=loop)
 
-		with client as session:
-			try:
-				loop.run_until_complete(self.query(session, urls))
-			except asyncio.CancelledError:
-				sys.exit()
-			except Exception as error:
-				self.logger.error('An error occurred while dumping Domino account hashes')
-				sys.exit()
+		#with client as session:
+		try:
+			task = loop.create_task(self.query(client, urls))
+			loop.run_until_complete(task)
+			loop.close()
+		except asyncio.CancelledError:
+			sys.exit()
+		except Exception as error:
+			self.logger.error('An error occurred while dumping Domino account hashes')
+			sys.exit()
 
 	async def query(self, session, urls):
 		"""

--- a/domi_owned/hashdump.py
+++ b/domi_owned/hashdump.py
@@ -72,7 +72,7 @@ class HashDump(DomiOwned):
 			if 'No documents found' in str(soup.findAll('h2')):
 				break
 			else:
-				links = [a.attrs.get('href') for a in soup.select('a[href^=/names.nsf/]')]
+				links = [a.attrs.get('href') for a in soup.select('a[href^="/names.nsf/"]')]
 				for link in links:
 					if self.utilities.ACCOUNT_REGEX.search(link):
 						account_url = "{0}/names.nsf/{1}?OpenDocument".format(self.url, self.utilities.ACCOUNT_REGEX.search(link).group(1))


### PR DESCRIPTION
Hello, 
Very interesting project to lead pentesting stuffs against lotus note applications. But I encountered some issues when i ran it with two main packages : beautifulsoup4 and asyncio.
The first issue concerns a syntax error in the parsing : 
<pre><code>Traceback (most recent call last):
  File "domi-owned.py", line 107, in <module>
    main()
  File "domi-owned.py", line 89, in main
    domino.dump()
  File "/home/jnt/tools/PostExploit/domi-owned/domi_owned/hashdump.py", line 43, in dump
    account_urls = self.get_accounts()
  File "/home/jnt/tools/PostExploit/domi-owned/domi_owned/hashdump.py", line 75, in get_accounts
    links = [a.attrs.get('href') for a in soup.select('a[href^=/names.nsf/]')]
  File "/usr/lib/python3.7/site-packages/bs4/element.py", line 1376, in select
    return soupsieve.select(selector, self, namespaces, limit, **kwargs)
  File "/usr/lib/python3.7/site-packages/soupsieve/__init__.py", line 114, in select
    return compile(select, namespaces, flags, **kwargs).select(tag, limit)
  File "/usr/lib/python3.7/site-packages/soupsieve/__init__.py", line 63, in compile
    return cp._cached_css_compile(pattern, namespaces, custom, flags)
  File "/usr/lib/python3.7/site-packages/soupsieve/css_parser.py", line 214, in _cached_css_compile
    CSSParser(pattern, custom=custom_selectors, flags=flags).process_selectors(),
  File "/usr/lib/python3.7/site-packages/soupsieve/css_parser.py", line 1113, in process_selectors
    return self.parse_selectors(self.selector_iter(self.pattern), index, flags)
  File "/usr/lib/python3.7/site-packages/soupsieve/css_parser.py", line 946, in parse_selectors
    key, m = next(iselector)
  File "/usr/lib/python3.7/site-packages/soupsieve/css_parser.py", line 1100, in selector_iter
    raise SelectorSyntaxError(msg, self.pattern, index)
soupsieve.util.SelectorSyntaxError: Malformed attribute selector at position 1
  line 1:
a[href^=/names.nsf/]
</code></pre>
 
The second issue expects the use of async function with the declaration of an aiohttp session : 
<pre><code>Traceback (most recent call last):
  File "domi-owned.py", line 107, in <module>
    main()
  File "domi-owned.py", line 73, in main
    domino.enumerate(args.wordlist)
  File "/home/jnt/tools/PostExploit/domi-owned/domi_owned/enumerate.py", line 41, in enumerate
    self.enum_dirs(urls)
  File "/home/jnt/tools/PostExploit/domi-owned/domi_owned/enumerate.py", line 100, in enum_dirs
    with client as session:
  File "/usr/lib/python3.7/site-packages/aiohttp/client.py", line 956, in __enter__
    raise TypeError("Use async with instead")
TypeError: Use async with instead
</code></pre>

I fix them and want to pull request to your project if you are interested
